### PR TITLE
src: handle _NET_CLOSE_WINDOW root message

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ WM\_CLIENT\_MACHINE - emwh.set_hostname(windowId, cb)
 
 \_NET\_WM\_CM\_S0 - emwh.set_composite_manager_owner(windowId, screenNo, cb)
 
+\_NET\_CLOSE\_WINDOW - ewmh.close_window(windowId, delete_protocol);
+
 =======
 
 EVENTS
@@ -71,6 +73,5 @@ Events are generated whenever a client requests the modification of a HINT.
 
 *CurrentDesktop* - \_NET\_CURRENT\_DESKTOP
 
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/santigimeno/node-ewmh/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+*Close Window* - \_NET\_CLOSE\_WINDOW
 

--- a/lib/ewmh.js
+++ b/lib/ewmh.js
@@ -112,6 +112,29 @@ EWMH.prototype.set_window_manager_owner = function(wid, name, _class, cb) {
     ], cb);
 };
 
+EWMH.prototype.close_window = function(wid, delete_protocol) {
+    if (delete_protocol) {
+        this.send_client_message(wid,
+                                 this.X.atoms.WM_PROTOCOLS,
+                                 this.X.atoms.WM_DELETE_WINDOW);
+    } else {
+        this.X.KillClient(wid);
+    }
+};
+
+EWMH.prototype.send_client_message = function(dest, type, data) {
+    var raw = new Buffer(new Array(32));
+    raw.writeInt8(33, 0); /* ClientMessage code */
+    if (type === this.X.atoms.WM_PROTOCOLS) {
+        raw.writeInt8(32, 1); /* Format */
+        raw.writeUInt32LE(dest, 4);
+        raw.writeUInt32LE(type, 8); /* Message Type */
+        raw.writeUInt32LE(data, 12); /* For WM_PROTOCOLS data === Protocol */
+    }
+
+    this.X.SendEvent(dest, false, 0, raw);
+};
+
 EWMH.prototype._handle_event = function(ev) {
     var self = this;
     switch(ev.name) {
@@ -124,6 +147,10 @@ EWMH.prototype._handle_event = function(ev) {
 
                     case '_NET_CURRENT_DESKTOP':
                         self.emit('CurrentDesktop', ev.data[0]);
+                    break;
+
+                    case '_NET_CLOSE_WINDOW':
+                        self.emit('CloseWindow', ev.wid);
                     break;
                 }
             });


### PR DESCRIPTION
- It emits CloseWindow event when the message is received.
- Add close_window method to be used by window managers. It supports
  the WM_DELETE_WINDOW protocol.
- Add a send_client_message function for window managers.
